### PR TITLE
Added chat feature

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@ NETWORK=testnet
 
 SKIP_SYNCHRONIZATION_BEFORE_HEIGHT=1100100
 
-CONTRACT_ID=6QMfQTdKpC3Y9uWBcTwXeY3KdzRLDqASUsDnQ4MEc9XC
+CONTRACT_ID=EKgnuhbG1zRi543hBFNXqfMM8ZMLWka6kiPUd3eeoWuU
 
 # TEMP VARS
 MNEMONIC="rescue tomato call picture bean submit teach deliver negative mutual second hole"

--- a/actions/getPoolByIdAction.js
+++ b/actions/getPoolByIdAction.js
@@ -2,6 +2,7 @@ import logger from "../logger.js";
 import PoolNotFoundError from "../errors/PoolNotFoundError.js";
 import PoolRepository from "../repositories/PoolRepository.js";
 import UtxoRepository from "../repositories/UtxoRepository.js";
+import MessageRepository from "../repositories/MessageRepository.js";
 import fetchUtxoByTxHashAndVout from "../utils/fetchUtxoByTxHashAndVout.js";
 import PoolMember from "../models/PoolMember.js";
 
@@ -13,6 +14,7 @@ const getPoolByIdAction = (sdk) => {
   return async (poolId) => {
     const poolRepository = new PoolRepository(sdk);
     const utxoRepository = new UtxoRepository(sdk);
+    const messageRepository = new MessageRepository(sdk);
 
     const pool = await poolRepository.getById(poolId);
 
@@ -49,6 +51,12 @@ const getPoolByIdAction = (sdk) => {
 
     logger.info(`Fetched pool document:\n${JSON.stringify(pool, null, 2)}`);
     logger.info(`Pool Info:\n${JSON.stringify(pooInfo, null, 2)}`);
+
+    const messages = await messageRepository.get(poolId);
+    logger.info(
+      `Chat messages for pool ${poolId}:\n` +
+      JSON.stringify(messages, null, 2)
+    );
 
     return pool;
   }

--- a/actions/sendPoolMessageAction.js
+++ b/actions/sendPoolMessageAction.js
@@ -1,0 +1,34 @@
+import logger from "../logger.js";
+import PoolNotFoundError from "../errors/PoolNotFoundError.js";
+import PoolRepository from "../repositories/PoolRepository.js";
+import MessageRepository from "../repositories/MessageRepository.js";
+
+/**
+ * @param {Client} sdk
+ * @returns {function(string, string): Promise<Message>}
+ */
+const sendPoolMessageAction = (sdk) => {
+  return async (poolId, text) => {
+    const poolRepository = new PoolRepository(sdk);
+    const messageRepository = new MessageRepository(sdk);
+
+    // 1. Fetch the pool by ID to ensure it exists
+    const pool = await poolRepository.getById(poolId);
+    if (!pool) {
+      throw new PoolNotFoundError(poolId);
+    }
+
+    // 2. Send the message in the pool chat
+    const message = await messageRepository.send(poolId, text);
+
+    // 3. Log the sent message
+    logger.info(
+      `Sent message to pool ${poolId}:\n` +
+      JSON.stringify(message, null, 2)
+    );
+
+    return message;
+  };
+};
+
+export default sendPoolMessageAction;

--- a/commands/pool/PoolCommand.js
+++ b/commands/pool/PoolCommand.js
@@ -2,10 +2,12 @@ import BaseCommand from "../BaseCommand.js";
 import CreatePoolCommand from "./subcommand/CreatePoolCommand.js";
 import GetPoolCommand from "./subcommand/GetPoolCommand.js";
 import JoinPoolCommand from "./subcommand/JoinPoolCommand.js";
+import SendPoolMessageCommand from "./subcommand/SendPoolMessageCommand.js";
 
 const createPoolCommand = new CreatePoolCommand()
 const getPoolCommand = new GetPoolCommand()
 const joinPoolCommand = new JoinPoolCommand()
+const sendPoolMessageCommand = new SendPoolMessageCommand()
 
 class PoolCommand extends BaseCommand {
   constructor() {
@@ -14,6 +16,7 @@ class PoolCommand extends BaseCommand {
       .addCommand(createPoolCommand)
       .addCommand(getPoolCommand)
       .addCommand(joinPoolCommand)
+      .addCommand(sendPoolMessageCommand)
   }
 }
 

--- a/commands/pool/subcommand/SendPoolMessageCommand.js
+++ b/commands/pool/subcommand/SendPoolMessageCommand.js
@@ -1,0 +1,14 @@
+import BaseCommand from "../../BaseCommand.js";
+import sendPoolMessageAction from "../../../actions/sendPoolMessageAction.js";
+
+class SendPoolMessageCommand extends BaseCommand {
+  constructor() {
+    super("message");
+    this.description("Send a message to the pool chat")
+      .argument('<poolId>', 'ID of the pool')
+      .argument('<text>', 'Message text')
+      .action(sendPoolMessageAction);
+  }
+}
+
+export default SendPoolMessageCommand;

--- a/errorHandler.js
+++ b/errorHandler.js
@@ -3,6 +3,7 @@ import InvalidPoolTypeError from "./errors/InvalidPoolTypeError.js";
 import InvalidTopUpAmountError from "./errors/InvalidTopUpAmountError.js";
 import PoolNotFoundError from "./errors/PoolNotFoundError.js";
 import UtxoNotFoundError from "./errors/UtxoNotFoundError.js";
+import userNotInPoolError from "./errors/UserNotInPoolError.js";
 
 /**
  * @param {Error} error
@@ -15,6 +16,8 @@ function errorHandler(error) {
   } else if (error instanceof PoolNotFoundError) {
     program.error(error.message);
   } else if (error instanceof UtxoNotFoundError) {
+    program.error(error.message);
+  } else if (error instanceof userNotInPoolError) {
     program.error(error.message);
   } else {
     throw error;

--- a/errors/UserNotInPoolError.js
+++ b/errors/UserNotInPoolError.js
@@ -1,0 +1,17 @@
+/**
+ * Error thrown when a user is not a member of a pool.
+ */
+class UserNotInPoolError extends Error {
+  /**
+   * @param {string=} poolId - The ID of the pool the user attempted to access.
+   */
+  constructor(poolId = undefined) {
+    const message = poolId
+      ? `User is not a member of pool ${poolId}`
+      : 'User is not a member of pool';
+    super(message);
+    this.name = 'UserNotInPoolError';
+  }
+}
+
+export default UserNotInPoolError;

--- a/models/Message.js
+++ b/models/Message.js
@@ -1,0 +1,38 @@
+import logger from "../logger.js";
+
+/**
+ * Class representing a chat Message.
+ */
+class Message {
+  /**
+   * @param {string} channel - Channel ID: 'global' or poolId.
+   * @param {string} text - Chat message text.
+   * @param {string=} createdAt - The creation date.
+   * @param {string=} updatedAt - The update date.
+   */
+  constructor(channel, text, createdAt = undefined, updatedAt = undefined) {
+    this.channel = channel;
+    this.text = text;
+    this.createdAt = createdAt ?? null;
+    this.updatedAt = updatedAt ?? null;
+  }
+
+  /**
+   * Create a Message instance from a Dash document.
+   *
+   * @param {Document} doc - Document returned by Dash SDK.
+   * @returns {Message}
+   */
+  static fromDocument(doc) {
+    const data = doc.toJSON();
+
+    return new Message(
+      data.channel,
+      data.text,
+      data['$createdAt'],
+      data['$updatedAt'],
+    );
+  }
+}
+
+export default Message;

--- a/repositories/MessageRepository.js
+++ b/repositories/MessageRepository.js
@@ -1,0 +1,125 @@
+import Dash from "dash";
+import bs58 from "bs58";
+import { APP_NAME } from "../constants.js";
+import Message from "../models/Message.js";
+import logger from "../logger.js";
+import config from "../config.js";
+import UserNotInPoolError from "../errors/UserNotInPoolError.js";
+
+const Client = Dash.Client;
+
+class MessageRepository {
+  #docName = 'message';
+
+  /**
+   * @param {Client} sdk - SDK instance for Dash platform
+   */
+  constructor(sdk) {
+    this.sdk = sdk;
+  }
+
+  /**
+   * Ensure that the current identity has at least one UTXO in the pool.
+   *
+   * @param {string} channel - Channel ID (poolId or 'global')
+   * @throws {UserNotInPoolError} if user is not a member of the pool
+   */
+  async _ensureMembership(channel) {
+    // Skip membership check for global channel
+    if (channel === 'global') {
+      return;
+    }
+
+    const { platform } = this.sdk;
+
+    // Decode poolId from Base58 to Buffer
+    const poolIdBuffer = bs58.decode(channel);
+
+    // Fetch UTXO documents for this pool
+    const utxoDocs = await platform.documents.get(
+      `${APP_NAME}.utxo`,
+      { where: [['poolId', '==', poolIdBuffer]] },
+    );
+
+    // Get the identity object for current user
+    const identity = await platform.identities.get(config.identity);
+    const myId = identity.getId();
+
+    // Check if any UTXO document owner matches current identity
+    const isMember = utxoDocs.some((doc) => doc.getOwnerId().equals(myId));
+
+    if (!isMember) {
+      throw new UserNotInPoolError(channel);
+    }
+  }
+
+  /**
+   * Fetches the last 10 messages from a channel, in chronological order.
+   *
+   * @param {string} channel - Channel ID: 'global' or poolId.
+   * @returns {Promise<Message[]>}
+   * @throws {UserNotInPoolError}
+   */
+  async get(channel) {
+    // Verify pool membership
+    await this._ensureMembership(channel);
+
+    const { platform } = this.sdk;
+
+    // Query last 10 messages, sorted by createdAt descending
+    const messageDocs = await platform.documents.get(
+      `${APP_NAME}.${this.#docName}`,
+      {
+        where: [['channel', '==', channel]],
+        orderBy: [['$createdAt', 'desc']],
+        limit: 10,
+      },
+    );
+
+    // Reverse to chronological order (oldest → newest)
+    const chronological = messageDocs.reverse();
+
+    // Map to domain model
+    return chronological.map((doc) => Message.fromDocument(doc));
+  }
+
+  /**
+   * Sends a new message to a specified channel.
+   *
+   * @param {string} channel - Channel ID: 'global' or poolId.
+   * @param {string} text - Chat message text.
+   * @returns {Promise<Message>}
+   * @throws {UserNotInPoolError}
+   */
+  async send(channel, text) {
+    // Verify pool membership
+    await this._ensureMembership(channel);
+
+    logger.info(`Sending message to channel: ${channel}`);
+
+    const { platform } = this.sdk;
+    // Get identity for signing the document
+    const identity = await platform.identities.get(config.identity);
+
+    // Create the message document
+    const msgDoc = await platform.documents.create(
+      `${APP_NAME}.${this.#docName}`,
+      identity,
+      { channel, text },
+    );
+
+    // Broadcast the new document
+    const batch = {
+      create: [msgDoc],
+      replace: [],
+      delete: [],
+    };
+    logger.log("Broadcasting Message Document");
+    await platform.documents.broadcast(batch, identity);
+    logger.log("Done..", `Message Document at: ${msgDoc.getId()}`);
+
+    return Message.fromDocument(msgDoc);
+  }
+}
+
+export default MessageRepository;

--- a/schema.json
+++ b/schema.json
@@ -73,8 +73,52 @@
       "$createdAt",
       "$updatedAt"
     ],
-    "indices":  [
-      {"properties":  ["poolId"]}
+    "indices": [
+      {
+        "name": "poolIdIndex",
+        "properties": [
+          {
+            "poolId": "asc"
+          }
+        ]
+      }
+    ],
+    "additionalProperties": false
+  },
+  "message": {
+    "type": "object",
+    "properties": {
+      "channel": {
+        "position": 0,
+        "type": "string",
+        "description": "Channel ID: 'global' or poolId",
+        "maxLength": 63
+      },
+      "text": {
+        "position": 1,
+        "type": "string",
+        "description": "Chat message text",
+        "maxLength": 1000
+      }
+    },
+    "required": [
+      "channel",
+      "text",
+      "$createdAt",
+      "$updatedAt"
+    ],
+    "indices": [
+      {
+        "name": "message_channel_createdAt",
+        "properties": [
+          {
+            "channel": "asc"
+          },
+          {
+            "$createdAt": "asc"
+          }
+        ]
+      }
     ],
     "additionalProperties": false
   }


### PR DESCRIPTION
### Description

This PR adds end-to-end chat support for pool contexts, enabling users to post and read messages scoped to a specific pool. It covers:

- A new `Message` model to represent chat entries.  
- A `MessageRepository` with `get(channel)` to fetch the last 10 messages in chronological order and `send(channel, text)` to post new messages.  
- Membership validation via a custom `UserNotInPoolError`, ensuring only pool participants can read or write.  
- Updates to `getPoolByIdAction` to log the latest chat history after loading pool details.  
- A `sendPoolMessageAction` and corresponding `SendPoolMessageCommand` CLI command (`message <poolId> <text>`) for sending messages.  
- Corrections to the Dash data contract schema for the `message` document’s index.

### Changes

- **Model**: Created `Message` class in `models/Message.js`.  
- **Repository**: Implemented `MessageRepository` in `repositories/MessageRepository.js` with membership check.  
- **Error Handling**: Added `UserNotInPoolError` in `errors/UserNotInPoolError.js`.  
- **Action**: Enhanced `getPoolByIdAction` to fetch & log pool chat messages.  
- **Action**: Added `sendPoolMessageAction` in `actions/sendPoolMessageAction.js`.  
- **CLI**: Introduced `SendPoolMessageCommand` in `commands/pool/subcommands/SendPoolMessageCommand.js`.  
- **Schema**: Added `message` document type in data contract schema.

### Testing

- **Unit**: Verified `MessageRepository.get` returns last 10 messages in order, and `send` correctly creates & broadcasts a message.  
- **Error Cases**: Confirmed non-members receive `UserNotInPoolError` when calling `get` or `send`.  
- **CLI**: Tested `message` command with valid pool IDs and with invalid/non-existent pools.  
- **Integration**: Ran `pool get` and ensured chat log appears in the console output after pool info.  