### PR TITLE
Action proposals

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@ NETWORK=testnet
 
 SKIP_SYNCHRONIZATION_BEFORE_HEIGHT=1100100
 
-CONTRACT_ID=6QMfQTdKpC3Y9uWBcTwXeY3KdzRLDqASUsDnQ4MEc9XC
+CONTRACT_ID=EKgnuhbG1zRi543hBFNXqfMM8ZMLWka6kiPUd3eeoWuU
 
 # TEMP VARS
 MNEMONIC="rescue tomato call picture bean submit teach deliver negative mutual second hole"

--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@ NETWORK=testnet
 
 SKIP_SYNCHRONIZATION_BEFORE_HEIGHT=1100100
 
-CONTRACT_ID=EKgnuhbG1zRi543hBFNXqfMM8ZMLWka6kiPUd3eeoWuU
+CONTRACT_ID=5i8nTDZ1NjLBxopGqJCcYQxxKcBCAggnWReaoJrBembk
 
 # TEMP VARS
 MNEMONIC="rescue tomato call picture bean submit teach deliver negative mutual second hole"

--- a/actions/createActionProposalAction.js
+++ b/actions/createActionProposalAction.js
@@ -1,0 +1,46 @@
+import logger from "../logger.js";
+import PoolRepository from "../repositories/PoolRepository.js";
+import PoolNotFoundError from "../errors/PoolNotFoundError.js";
+import ActionProposalRepository from "../repositories/ActionProposalRepository.js";
+import OnlyPoolOwnerError from "../errors/OnlyPoolOwnerError.js";
+import config from "../config.js";
+
+/**
+ * @param {Client} sdk
+ * @returns {function(string, string, string): Promise<ActionProposal>}
+ */
+const createActionProposalAction = (sdk) => {
+  return async (poolId, transactionHex, description) => {
+    const poolRepo = new PoolRepository(sdk);
+
+    // 1. Ensure the pool exists
+    const pool = await poolRepo.getById(poolId);
+    if (!pool) {
+      throw new PoolNotFoundError(poolId);
+    }
+
+    // 2. Ensure caller is the pool owner
+    const identity = await sdk.platform.identities.get(config.identity);
+    const callerId = identity.getId().toString();
+    if (callerId !== pool.ownerId) {
+      throw new OnlyPoolOwnerError(poolId);
+    }
+
+    // 3. Create the proposal
+    const proposalRepo = new ActionProposalRepository(sdk);
+    const proposal = await proposalRepo.create({
+      poolId,
+      transactionHex,
+      description,
+    });
+
+    // 4. Log the created proposal
+    logger.info(
+      `Created action proposal:\n${JSON.stringify(proposal, null, 2)}`
+    );
+
+    return proposal;
+  };
+};
+
+export default createActionProposalAction;

--- a/actions/createActionProposalSignatureAction.js
+++ b/actions/createActionProposalSignatureAction.js
@@ -1,0 +1,30 @@
+import logger from "../logger.js";
+import ActionProposalNotFoundError from "../errors/ActionProposalNotFoundError.js";
+import ActionProposalRepository from "../repositories/ActionProposalRepository.js";
+import ActionProposalSignatureRepository from "../repositories/ActionProposalSignatureRepository.js";
+
+/**
+ * @param {Client} sdk
+ * @returns {function(string, string): Promise<ActionProposalSignature>}
+ */
+const createActionProposalSignatureAction = (sdk) => {
+  return async (proposalId, signature) => {
+    const proposalRepo = new ActionProposalRepository(sdk);
+    const proposal = await proposalRepo.getById(proposalId);
+    if (!proposal) {
+      throw new ActionProposalNotFoundError(proposalId);
+    }
+
+    const sigRepo = new ActionProposalSignatureRepository(sdk);
+    const sig = await sigRepo.create({ proposalId, signature });
+
+    logger.info(
+      `Created signature ${sig.id} for proposal ${proposalId}:\n` +
+      JSON.stringify(sig, null, 2)
+    );
+
+    return sig;
+  };
+};
+
+export default createActionProposalSignatureAction;

--- a/actions/createPoolAction.js
+++ b/actions/createPoolAction.js
@@ -18,7 +18,7 @@ const createPoolAction = (sdk) => {
       throw new InvalidPoolTypeError();
     }
 
-    const pool = new Pool(name, description, type, status);
+    const pool = new Pool(null, name, description, type, status);
 
     await poolRepository.create(pool);
   };

--- a/actions/getActionProposalByIdAction.js
+++ b/actions/getActionProposalByIdAction.js
@@ -1,0 +1,24 @@
+import ActionProposalRepository from "../repositories/ActionProposalRepository.js";
+import ActionProposalNotFoundError from "../errors/ActionProposalNotFoundError.js";
+
+/**
+ * @param {Client} sdk
+ * @returns {function(string): Promise<ActionProposal>}
+ */
+const getActionProposalByIdAction = (sdk) => {
+  return async (proposalId) => {
+    const repo = new ActionProposalRepository(sdk);
+
+    // Fetch the proposal by ID
+    const proposal = await repo.getById(proposalId);
+
+    // Throw custom error if not found
+    if (!proposal) {
+      throw new ActionProposalNotFoundError(proposalId);
+    }
+
+    return proposal;
+  };
+};
+
+export default getActionProposalByIdAction;

--- a/actions/getActionProposalByIdAction.js
+++ b/actions/getActionProposalByIdAction.js
@@ -1,5 +1,7 @@
-import ActionProposalRepository from "../repositories/ActionProposalRepository.js";
+import logger from "../logger.js";
 import ActionProposalNotFoundError from "../errors/ActionProposalNotFoundError.js";
+import ActionProposalRepository from "../repositories/ActionProposalRepository.js";
+import ActionProposalSignatureRepository from "../repositories/ActionProposalSignatureRepository.js"; // см. ниже
 
 /**
  * @param {Client} sdk
@@ -7,15 +9,29 @@ import ActionProposalNotFoundError from "../errors/ActionProposalNotFoundError.j
  */
 const getActionProposalByIdAction = (sdk) => {
   return async (proposalId) => {
-    const repo = new ActionProposalRepository(sdk);
+    const proposalRepo = new ActionProposalRepository(sdk);
+    const signatureRepo = new ActionProposalSignatureRepository(sdk);
 
-    // Fetch the proposal by ID
-    const proposal = await repo.getById(proposalId);
-
-    // Throw custom error if not found
+    // 1. Fetch the proposal by ID
+    const proposal = await proposalRepo.getById(proposalId);
     if (!proposal) {
       throw new ActionProposalNotFoundError(proposalId);
     }
+
+    // 2. Fetch all signatures for this proposal
+    const signatures = await signatureRepo.getByProposalId(proposalId);
+
+    // 3. Log the proposal and its signatures
+    logger.info(
+      `Fetched action proposal:\n${JSON.stringify(proposal, null, 2)}`
+    );
+    logger.info(
+      `Signatures for proposal ${proposalId}:\n${JSON.stringify(
+        signatures,
+        null,
+        2
+      )}`
+    );
 
     return proposal;
   };

--- a/actions/getActionProposalByPoolIdAction.js
+++ b/actions/getActionProposalByPoolIdAction.js
@@ -1,0 +1,34 @@
+// actions/getActionProposalByPoolIdAction.js
+import logger from "../logger.js";
+import PoolNotFoundError from "../errors/PoolNotFoundError.js";
+import PoolRepository from "../repositories/PoolRepository.js";
+import ActionProposalRepository from "../repositories/ActionProposalRepository.js";
+
+/**
+ * @param {Client} sdk
+ * @returns {function(string): Promise<ActionProposal[]>}
+ */
+const getActionProposalByPoolIdAction = (sdk) => {
+  return async (poolId) => {
+    // 1. Fetch the pool and ensure it exists
+    const poolRepository = new PoolRepository(sdk);
+    const pool = await poolRepository.getById(poolId);
+    if (!pool) {
+      throw new PoolNotFoundError(poolId);
+    }
+
+    // 2. Fetch action proposals created by the pool owner
+    const proposalRepository = new ActionProposalRepository(sdk);
+    const proposals = await proposalRepository.getByPoolId(poolId);
+
+    // 3. Log fetched proposals
+    logger.info(
+      `Fetched ${proposals.length} action proposal(s) for pool ${poolId}:\n` +
+      JSON.stringify(proposals, null, 2)
+    );
+
+    return proposals;
+  };
+};
+
+export default getActionProposalByPoolIdAction;

--- a/actions/getActionProposalSignatureByIdAction.js
+++ b/actions/getActionProposalSignatureByIdAction.js
@@ -1,0 +1,26 @@
+import logger from "../logger.js";
+import ActionProposalSignatureNotFoundError from "../errors/ActionProposalSignatureNotFoundError.js";
+import ActionProposalSignatureRepository from "../repositories/ActionProposalSignatureRepository.js";
+
+/**
+ * @param {Client} sdk
+ * @returns {function(string): Promise<ActionProposalSignature>}
+ */
+const getActionProposalSignatureByIdAction = (sdk) => {
+  return async (signatureId) => {
+    const sigRepo = new ActionProposalSignatureRepository(sdk);
+    const sig = await sigRepo.getById(signatureId);
+    if (!sig) {
+      throw new ActionProposalSignatureNotFoundError(signatureId);
+    }
+
+    logger.info(
+      `Fetched signature ${signatureId}:\n` +
+      JSON.stringify(sig, null, 2)
+    );
+
+    return sig;
+  };
+};
+
+export default getActionProposalSignatureByIdAction;

--- a/actions/getActionProposalSignatureByProposalIdAction.js
+++ b/actions/getActionProposalSignatureByProposalIdAction.js
@@ -1,0 +1,30 @@
+import logger from "../logger.js";
+import ActionProposalNotFoundError from "../errors/ActionProposalNotFoundError.js";
+import ActionProposalRepository from "../repositories/ActionProposalRepository.js";
+import ActionProposalSignatureRepository from "../repositories/ActionProposalSignatureRepository.js";
+
+/**
+ * @param {Client} sdk
+ * @returns {function(string): Promise<ActionProposalSignature[]>}
+ */
+const getActionProposalSignatureByProposalIdAction = (sdk) => {
+  return async (proposalId) => {
+    const proposalRepo = new ActionProposalRepository(sdk);
+    const proposal = await proposalRepo.getById(proposalId);
+    if (!proposal) {
+      throw new ActionProposalNotFoundError(proposalId);
+    }
+
+    const sigRepo = new ActionProposalSignatureRepository(sdk);
+    const signatures = await sigRepo.getByProposalId(proposalId);
+
+    logger.info(
+      `Fetched ${signatures.length} signature(s) for proposal ${proposalId}:\n` +
+      JSON.stringify(signatures, null, 2)
+    );
+
+    return signatures;
+  };
+};
+
+export default getActionProposalSignatureByProposalIdAction;

--- a/commands/proposal/ProposalCommand.js
+++ b/commands/proposal/ProposalCommand.js
@@ -1,0 +1,20 @@
+import BaseCommand from "../BaseCommand.js";
+import GetActionProposalByIdCommand from "./subcommand/GetActionProposalByIdCommand.js";
+import GetActionProposalByPoolIdCommand from "./subcommand/GetActionProposalByPoolIdCommand.js";
+import CreateActionProposalCommand from "./subcommand/CreateActionProposalCommand.js";
+
+const getByIdCommand = new GetActionProposalByIdCommand();
+const listByPoolCommand = new GetActionProposalByPoolIdCommand();
+const createProposalCommand = new CreateActionProposalCommand();
+
+class ActionProposalCommand extends BaseCommand {
+  constructor() {
+    super("proposal");
+    this.description("Commands to manage action proposals")
+      .addCommand(getByIdCommand)
+      .addCommand(listByPoolCommand)
+      .addCommand(createProposalCommand);
+  }
+}
+
+export default ActionProposalCommand;

--- a/commands/proposal/subcommand/CreateActionProposalCommand.js
+++ b/commands/proposal/subcommand/CreateActionProposalCommand.js
@@ -1,0 +1,15 @@
+import BaseCommand from "../../BaseCommand.js";
+import createActionProposalAction from "../../../actions/createActionProposalAction.js";
+
+class CreateActionProposalCommand extends BaseCommand {
+  constructor() {
+    super("create");
+    this.description("Create a new action proposal for a pool")
+      .argument('<poolId>', 'The ID of the pool')
+      .argument('<transactionHex>', 'Unsigned multisig transaction hex')
+      .argument('<description>', 'Human-readable description of the proposal')
+      .action(createActionProposalAction);
+  }
+}
+
+export default CreateActionProposalCommand;

--- a/commands/proposal/subcommand/GetActionProposalByIdCommand.js
+++ b/commands/proposal/subcommand/GetActionProposalByIdCommand.js
@@ -1,0 +1,13 @@
+import BaseCommand from "../../BaseCommand.js";
+import getActionProposalByIdAction from "../../../actions/getActionProposalByIdAction.js";
+
+class GetActionProposalByIdCommand extends BaseCommand {
+  constructor() {
+    super("get");
+    this.description("Get an action proposal by its ID")
+      .argument('<proposalId>', 'The ID of the action proposal')
+      .action(getActionProposalByIdAction);
+  }
+}
+
+export default GetActionProposalByIdCommand;

--- a/commands/proposal/subcommand/GetActionProposalByPoolIdCommand.js
+++ b/commands/proposal/subcommand/GetActionProposalByPoolIdCommand.js
@@ -1,0 +1,13 @@
+import BaseCommand from "../../BaseCommand.js";
+import getActionProposalByPoolIdAction from "../../../actions/getActionProposalByPoolIdAction.js";
+
+class GetActionProposalByPoolIdCommand extends BaseCommand {
+  constructor() {
+    super("list");
+    this.description("List all action proposals created by the pool owner for a specific pool")
+      .argument('<poolId>', 'The ID of the pool')
+      .action(getActionProposalByPoolIdAction);
+  }
+}
+
+export default GetActionProposalByPoolIdCommand;

--- a/commands/signature/SignatureCommand.js
+++ b/commands/signature/SignatureCommand.js
@@ -1,0 +1,20 @@
+import BaseCommand from "../BaseCommand.js";
+import GetActionProposalSignatureByProposalIdCommand from "./subcommand/GetActionProposalSignatureByProposalIdCommand.js";
+import GetActionProposalSignatureByIdCommand from "./subcommand/GetActionProposalSignatureByIdCommand.js";
+import CreateActionProposalSignatureCommand from "./subcommand/CreateActionProposalSignatureCommand.js";
+
+const listByProposalCommand = new GetActionProposalSignatureByProposalIdCommand();
+const getByIdCommand = new GetActionProposalSignatureByIdCommand();
+const createSignatureCommand = new CreateActionProposalSignatureCommand();
+
+class SignatureCommand extends BaseCommand {
+  constructor() {
+    super("signature");
+    this.description("Commands to manage action proposal signatures")
+      .addCommand(listByProposalCommand)
+      .addCommand(getByIdCommand)
+      .addCommand(createSignatureCommand);
+  }
+}
+
+export default SignatureCommand;

--- a/commands/signature/subcommand/CreateActionProposalSignatureCommand.js
+++ b/commands/signature/subcommand/CreateActionProposalSignatureCommand.js
@@ -1,0 +1,14 @@
+import BaseCommand from "../../BaseCommand.js";
+import createActionProposalSignatureAction from "../../../actions/createActionProposalSignatureAction.js";
+
+class CreateActionProposalSignatureCommand extends BaseCommand {
+  constructor() {
+    super("create");
+    this.description("Create a new signature for an action proposal")
+      .argument('<proposalId>', 'The ID of the action proposal')
+      .argument('<signature>', "Member's signature string")
+      .action(createActionProposalSignatureAction);
+  }
+}
+
+export default CreateActionProposalSignatureCommand;

--- a/commands/signature/subcommand/GetActionProposalSignatureByIdCommand.js
+++ b/commands/signature/subcommand/GetActionProposalSignatureByIdCommand.js
@@ -1,0 +1,13 @@
+import BaseCommand from "../../BaseCommand.js";
+import getActionProposalSignatureByIdAction from "../../../actions/getActionProposalSignatureByIdAction.js";
+
+class GetActionProposalSignatureByIdCommand extends BaseCommand {
+  constructor() {
+    super("get");
+    this.description("Get a single signature by its ID")
+      .argument('<signatureId>', 'The ID of the signature')
+      .action(getActionProposalSignatureByIdAction);
+  }
+}
+
+export default GetActionProposalSignatureByIdCommand;

--- a/commands/signature/subcommand/GetActionProposalSignatureByProposalIdCommand.js
+++ b/commands/signature/subcommand/GetActionProposalSignatureByProposalIdCommand.js
@@ -1,0 +1,13 @@
+import BaseCommand from "../../BaseCommand.js";
+import getActionProposalSignatureByProposalIdAction from "../../../actions/getActionProposalSignatureByProposalIdAction.js";
+
+class GetActionProposalSignatureByProposalIdCommand extends BaseCommand {
+  constructor() {
+    super("list");
+    this.description("List all signatures for a given proposal")
+      .argument('<proposalId>', 'The ID of the action proposal')
+      .action(getActionProposalSignatureByProposalIdAction);
+  }
+}
+
+export default GetActionProposalSignatureByProposalIdCommand;

--- a/errors/ActionProposalNotFoundError.js
+++ b/errors/ActionProposalNotFoundError.js
@@ -1,0 +1,17 @@
+/**
+ * Error thrown when an action proposal cannot be found by ID.
+ */
+class ActionProposalNotFoundError extends Error {
+  /**
+   * @param {string=} proposalId - The ID of the missing proposal.
+   */
+  constructor(proposalId = undefined) {
+    const message = proposalId
+      ? `Action proposal with ID ${proposalId} not found`
+      : 'Action proposal not found';
+    super(message);
+    this.name = 'ActionProposalNotFoundError';
+  }
+}
+
+export default ActionProposalNotFoundError;

--- a/errors/ActionProposalSignatureNotFoundError.js
+++ b/errors/ActionProposalSignatureNotFoundError.js
@@ -1,0 +1,17 @@
+/**
+ * Error thrown when an action proposal signature cannot be found by ID.
+ */
+class ActionProposalSignatureNotFoundError extends Error {
+  /**
+   * @param {string=} signatureId - The ID of the missing signature.
+   */
+  constructor(signatureId = undefined) {
+    const message = signatureId
+      ? `Action proposal signature with ID ${signatureId} not found`
+      : 'Action proposal signature not found';
+    super(message);
+    this.name = 'ActionProposalSignatureNotFoundError';
+  }
+}
+
+export default ActionProposalSignatureNotFoundError;

--- a/errors/OnlyPoolOwnerError.js
+++ b/errors/OnlyPoolOwnerError.js
@@ -1,0 +1,17 @@
+/**
+ * Error thrown when someone other than the pool owner attempts an owner-only action.
+ */
+class OnlyPoolOwnerError extends Error {
+  /**
+   * @param {string=} poolId - ID of the pool for context.
+   */
+  constructor(poolId = undefined) {
+    const message = poolId
+      ? `Only the pool owner can perform this action on pool ${poolId}`
+      : 'Only the pool owner can perform this action';
+    super(message);
+    this.name = 'OnlyPoolOwnerError';
+  }
+}
+
+export default OnlyPoolOwnerError;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ import fs from "fs";
 import { program } from 'commander';
 import PoolCommand from "./commands/pool/PoolCommand.js";
 import IdentityCommand from "./commands/identity/IdentityCommand.js";
+import ActionProposalCommand from "./commands/proposal/ProposalCommand.js";
+import SignatureCommand from "./commands/signature/SignatureCommand.js";
 
 const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 
@@ -14,8 +16,12 @@ program
 
 const poolCommands = new PoolCommand()
 const identityCommands = new IdentityCommand()
+const proposalCommands = new ActionProposalCommand()
+const signatureCommands = new SignatureCommand()
 
 program.addCommand(poolCommands);
 program.addCommand(identityCommands);
+program.addCommand(proposalCommands);
+program.addCommand(signatureCommands);
 
 program.parse(process.argv);

--- a/models/ActionProposal.js
+++ b/models/ActionProposal.js
@@ -1,0 +1,39 @@
+/**
+ * Class representing an action proposal.
+ */
+class ActionProposal {
+  /**
+   * @param {Uint8Array|Buffer} poolId - Byte-array ID of the pool.
+   * @param {string} transactionHex - Unsigned multisig transaction in hex.
+   * @param {string} description - Human-readable explanation of the proposal.
+   * @param {string=} createdAt - ISO timestamp when the proposal was created.
+   * @param {string=} updatedAt - ISO timestamp when the proposal was last updated.
+   */
+  constructor(poolId, transactionHex, description, createdAt = undefined, updatedAt = undefined) {
+    this.poolId = poolId;
+    this.transactionHex = transactionHex;
+    this.description = description;
+    this.createdAt = createdAt ?? null;
+    this.updatedAt = updatedAt ?? null;
+  }
+
+  /**
+   * Create an ActionProposal instance from a Dash Document.
+   *
+   * @param {Document} doc - Document returned by the Dash SDK.
+   * @returns {ActionProposal}
+   */
+  static fromDocument(doc) {
+    const data = doc.toJSON();
+
+    return new ActionProposal(
+      data.poolId,
+      data.transactionHex,
+      data.description,
+      data["$createdAt"],
+      data["$updatedAt"],
+    );
+  }
+}
+
+export default ActionProposal;

--- a/models/ActionProposal.js
+++ b/models/ActionProposal.js
@@ -3,7 +3,8 @@
  */
 class ActionProposal {
   /**
-   * @param {Uint8Array|Buffer} poolId - Byte-array ID of the pool.
+   * Creates an instance of ActionProposal.
+   * @param {string} poolId - Base58-encoded ID of the pool.
    * @param {string} transactionHex - Unsigned multisig transaction in hex.
    * @param {string} description - Human-readable explanation of the proposal.
    * @param {string=} createdAt - ISO timestamp when the proposal was created.
@@ -18,9 +19,9 @@ class ActionProposal {
   }
 
   /**
-   * Create an ActionProposal instance from a Dash Document.
+   * Instantiate an ActionProposal from a Dash Document.
    *
-   * @param {Document} doc - Document returned by the Dash SDK.
+   * @param {Document} doc - Document returned by Dash SDK.
    * @returns {ActionProposal}
    */
   static fromDocument(doc) {

--- a/models/ActionProposalSignature.js
+++ b/models/ActionProposalSignature.js
@@ -1,0 +1,38 @@
+/**
+ * Class representing a signature for an action proposal.
+ */
+class ActionProposalSignature {
+  /**
+   * @param {string} proposalId - ID of the action_proposal document.
+   * @param {string} signature - The member's signature string.
+   * @param {Uint8Array|Buffer} ownerId - Identity ID of the signer.
+   * @param {string=} createdAt - ISO timestamp when created.
+   * @param {string=} updatedAt - ISO timestamp when updated.
+   */
+  constructor(proposalId, signature, ownerId, createdAt = undefined, updatedAt = undefined) {
+    this.proposalId = proposalId;
+    this.signature = signature;
+    this.ownerId = ownerId;
+    this.createdAt = createdAt ?? null;
+    this.updatedAt = updatedAt ?? null;
+  }
+
+  /**
+   * Instantiate from a Dash Document.
+   *
+   * @param {Document} doc
+   * @returns {ActionProposalSignature}
+   */
+  static fromDocument(doc) {
+    const data = doc.toJSON();
+    return new ActionProposalSignature(
+      data.proposalId,
+      data.signature,
+      doc.getOwnerId(),
+      data['$createdAt'],
+      data['$updatedAt'],
+    );
+  }
+}
+
+export default ActionProposalSignature;

--- a/models/Pool.js
+++ b/models/Pool.js
@@ -10,6 +10,7 @@ class Pool {
    * Creates an instance of Pool.
    *
    * @param {string | null} id - The id of the pool.
+   * @param {string | null} ownerId - The id owner of the pool.
    * @param {string} name - The name of the pool.
    * @param {string} description - The description of the pool.
    * @param {MasternodeTypeEnum} type - The type of the pool ("MASTERNODE" or "EVONODE").
@@ -17,8 +18,9 @@ class Pool {
    * @param {string=} createdAt - The creation date.
    * @param {string=} updatedAt - The update date.
    */
-  constructor(id = null, name, description, type, status, createdAt = undefined, updatedAt = undefined) {
+  constructor(name, description, type, status, id = null, ownerId = null, createdAt = undefined, updatedAt = undefined) {
     this.id = id;
+    this.ownerId = ownerId;
     this.name = name;
     this.description = description;
     this.type = type;
@@ -30,11 +32,12 @@ class Pool {
   static fromDocument(appData) {
     appData = appData.toJSON();
     return new Pool(
-      appData['$id'],
       appData.name,
       appData.description,
       appData.type,
       appData.status,
+      appData['$id'],
+      appData['$ownerId'],
       appData['$createdAt'],
       appData['$updatedAt'],
     )

--- a/models/Pool.js
+++ b/models/Pool.js
@@ -18,7 +18,7 @@ class Pool {
    * @param {string=} createdAt - The creation date.
    * @param {string=} updatedAt - The update date.
    */
-  constructor(name, description, type, status, id = null, ownerId = null, createdAt = undefined, updatedAt = undefined) {
+  constructor(id = null, name, description, type, status, ownerId = null, createdAt = undefined, updatedAt = undefined) {
     this.id = id;
     this.ownerId = ownerId;
     this.name = name;
@@ -32,11 +32,11 @@ class Pool {
   static fromDocument(appData) {
     appData = appData.toJSON();
     return new Pool(
+      appData['$id'],
       appData.name,
       appData.description,
       appData.type,
       appData.status,
-      appData['$id'],
       appData['$ownerId'],
       appData['$createdAt'],
       appData['$updatedAt'],

--- a/repositories/ActionProposalRepository.js
+++ b/repositories/ActionProposalRepository.js
@@ -1,17 +1,17 @@
 import Dash from "dash";
-import bs58 from "bs58";
 import { APP_NAME } from "../constants.js";
 import ActionProposal from "../models/ActionProposal.js";
 import config from "../config.js";
 import logger from "../logger.js";
 
-const Client = Dash.Client;
-
+/**
+ * Repository for action_proposal documents.
+ */
 class ActionProposalRepository {
   #docName = "action_proposal";
 
   /**
-   * @param {Client} sdk - Dash SDK instance
+   * @param {Client} sdk - Dash SDK Client instance.
    */
   constructor(sdk) {
     this.sdk = sdk;
@@ -21,14 +21,14 @@ class ActionProposalRepository {
    * Fetch a proposal by its document ID.
    *
    * @param {string} proposalId - Base58-encoded ID of the action_proposal document.
-   * @returns {Promise<ActionProposal|null>}
+   * @returns {Promise<ActionProposal|null>} ActionProposal instance or null if not found.
    */
   async getById(proposalId) {
     const { platform } = this.sdk;
 
     const [doc] = await platform.documents.get(
       `${APP_NAME}.${this.#docName}`,
-      { where: [["$id", "==", proposalId]] }
+      { where: [["$id", "==", proposalId]] },
     );
 
     if (!doc) {
@@ -42,15 +42,14 @@ class ActionProposalRepository {
    * Fetch all proposals created for a specific pool.
    *
    * @param {string} poolId - Base58-encoded Pool ID.
-   * @returns {Promise<ActionProposal[]>}
+   * @returns {Promise<ActionProposal[]>} Array of ActionProposal instances.
    */
   async getByPoolId(poolId) {
     const { platform } = this.sdk;
-    const poolIdBuffer = bs58.decode(poolId);
 
     const docs = await platform.documents.get(
       `${APP_NAME}.${this.#docName}`,
-      { where: [["poolId", "==", poolIdBuffer]] }
+      { where: [["poolId", "==", poolId]] },
     );
 
     return docs.map((doc) => ActionProposal.fromDocument(doc));
@@ -59,7 +58,7 @@ class ActionProposalRepository {
   /**
    * Create a new action proposal. Only the pool owner should call this.
    *
-   * @param {object} proposalData
+   * @param {object} proposalData - Data for the new proposal.
    * @param {string} proposalData.poolId - Base58-encoded Pool ID.
    * @param {string} proposalData.transactionHex - Unsigned multisig transaction hex.
    * @param {string} proposalData.description - Human-readable description.
@@ -68,43 +67,30 @@ class ActionProposalRepository {
   async create({ poolId, transactionHex, description }) {
     const { platform } = this.sdk;
 
-    // Load the identity that will sign the document
+    // Load identity that signs the document (pool owner)
     const identity = await platform.identities.get(config.identity);
 
     logger.info(`Creating action proposal for pool ${poolId}`);
 
-    // Prepare the raw document data
-    const docData = {
-      poolId: bs58.decode(poolId),
-      transactionHex,
-      description,
-      createdAt: undefined,
-      updatedAt: undefined,
-    };
-
-    // Create the document
     const proposalDoc = await platform.documents.create(
       `${APP_NAME}.${this.#docName}`,
       identity,
-      docData
+      { poolId, transactionHex, description },
     );
 
-    // Broadcast the new proposal
     const batch = {
       create: [proposalDoc],
       replace: [],
       delete: [],
     };
+
     logger.log("Broadcasting ActionProposal document");
     await platform.documents.broadcast(batch, identity);
-
-    logger.log(
-      "Done..",
-      `ActionProposal Document at: ${proposalDoc.getId()}`
-    );
+    logger.log("Done..", `ActionProposal Document at: ${proposalDoc.getId()}`);
 
     return ActionProposal.fromDocument(proposalDoc);
   }
 }
 
 export default ActionProposalRepository;
+

--- a/repositories/ActionProposalRepository.js
+++ b/repositories/ActionProposalRepository.js
@@ -1,0 +1,110 @@
+import Dash from "dash";
+import bs58 from "bs58";
+import { APP_NAME } from "../constants.js";
+import ActionProposal from "../models/ActionProposal.js";
+import config from "../config.js";
+import logger from "../logger.js";
+
+const Client = Dash.Client;
+
+class ActionProposalRepository {
+  #docName = "action_proposal";
+
+  /**
+   * @param {Client} sdk - Dash SDK instance
+   */
+  constructor(sdk) {
+    this.sdk = sdk;
+  }
+
+  /**
+   * Fetch a proposal by its document ID.
+   *
+   * @param {string} proposalId - Base58-encoded ID of the action_proposal document.
+   * @returns {Promise<ActionProposal|null>}
+   */
+  async getById(proposalId) {
+    const { platform } = this.sdk;
+
+    const [doc] = await platform.documents.get(
+      `${APP_NAME}.${this.#docName}`,
+      { where: [["$id", "==", proposalId]] }
+    );
+
+    if (!doc) {
+      return null;
+    }
+
+    return ActionProposal.fromDocument(doc);
+  }
+
+  /**
+   * Fetch all proposals created for a specific pool.
+   *
+   * @param {string} poolId - Base58-encoded Pool ID.
+   * @returns {Promise<ActionProposal[]>}
+   */
+  async getByPoolId(poolId) {
+    const { platform } = this.sdk;
+    const poolIdBuffer = bs58.decode(poolId);
+
+    const docs = await platform.documents.get(
+      `${APP_NAME}.${this.#docName}`,
+      { where: [["poolId", "==", poolIdBuffer]] }
+    );
+
+    return docs.map((doc) => ActionProposal.fromDocument(doc));
+  }
+
+  /**
+   * Create a new action proposal. Only the pool owner should call this.
+   *
+   * @param {object} proposalData
+   * @param {string} proposalData.poolId - Base58-encoded Pool ID.
+   * @param {string} proposalData.transactionHex - Unsigned multisig transaction hex.
+   * @param {string} proposalData.description - Human-readable description.
+   * @returns {Promise<ActionProposal>}
+   */
+  async create({ poolId, transactionHex, description }) {
+    const { platform } = this.sdk;
+
+    // Load the identity that will sign the document
+    const identity = await platform.identities.get(config.identity);
+
+    logger.info(`Creating action proposal for pool ${poolId}`);
+
+    // Prepare the raw document data
+    const docData = {
+      poolId: bs58.decode(poolId),
+      transactionHex,
+      description,
+      createdAt: undefined,
+      updatedAt: undefined,
+    };
+
+    // Create the document
+    const proposalDoc = await platform.documents.create(
+      `${APP_NAME}.${this.#docName}`,
+      identity,
+      docData
+    );
+
+    // Broadcast the new proposal
+    const batch = {
+      create: [proposalDoc],
+      replace: [],
+      delete: [],
+    };
+    logger.log("Broadcasting ActionProposal document");
+    await platform.documents.broadcast(batch, identity);
+
+    logger.log(
+      "Done..",
+      `ActionProposal Document at: ${proposalDoc.getId()}`
+    );
+
+    return ActionProposal.fromDocument(proposalDoc);
+  }
+}
+
+export default ActionProposalRepository;

--- a/repositories/ActionProposalSignatureRepository.js
+++ b/repositories/ActionProposalSignatureRepository.js
@@ -1,0 +1,77 @@
+import Dash from "dash";
+import { APP_NAME } from "../constants.js";
+import ActionProposalSignature from "../models/ActionProposalSignature.js";
+import config from "../config.js";
+import logger from "../logger.js";
+
+class ActionProposalSignatureRepository {
+  #docName = "action_proposal_signature";
+
+  /**
+   * @param {Client} sdk
+   */
+  constructor(sdk) {
+    this.sdk = sdk;
+  }
+
+  /**
+   * Fetch all signatures for a given proposal.
+   *
+   * @param {string} proposalId
+   * @returns {Promise<ActionProposalSignature[]>}
+   */
+  async getByProposalId(proposalId) {
+    const { platform } = this.sdk;
+    const docs = await platform.documents.get(
+      `${APP_NAME}.${this.#docName}`,
+      { where: [["proposalId", "==", proposalId]] }
+    );
+    return docs.map((doc) => ActionProposalSignature.fromDocument(doc));
+  }
+
+  /**
+   * Fetch a single signature by its document ID.
+   *
+   * @param {string} signatureId
+   * @returns {Promise<ActionProposalSignature|null>}
+   */
+  async getById(signatureId) {
+    const { platform } = this.sdk;
+    const [doc] = await platform.documents.get(
+      `${APP_NAME}.${this.#docName}`,
+      { where: [["$id", "==", signatureId]] }
+    );
+    return doc ? ActionProposalSignature.fromDocument(doc) : null;
+  }
+
+  /**
+   * Create a new signature for an action proposal.
+   *
+   * @param {object} params
+   * @param {string} params.proposalId
+   * @param {string} params.signature
+   * @returns {Promise<ActionProposalSignature>}
+   */
+  async create({ proposalId, signature }) {
+    const { platform } = this.sdk;
+    const identity = await platform.identities.get(config.identity);
+
+    logger.info(`Creating signature for proposal ${proposalId}`);
+
+    const sigDoc = await platform.documents.create(
+      `${APP_NAME}.${this.#docName}`,
+      identity,
+      { proposalId, signature }
+    );
+
+    await platform.documents.broadcast(
+      { create: [sigDoc], replace: [], delete: [] },
+      identity,
+    );
+    logger.log("Done..", `Signature Document at: ${sigDoc.getId()}`);
+
+    return ActionProposalSignature.fromDocument(sigDoc);
+  }
+}
+
+export default ActionProposalSignatureRepository;

--- a/repositories/PoolRepository.js
+++ b/repositories/PoolRepository.js
@@ -54,7 +54,7 @@ class PoolRepository {
     const poolDocument = await platform.documents.create(
       `${APP_NAME}.${this.#docName}`,
       identity,
-      {...pool, createdAt: undefined, updatedAt: undefined, id: undefined},
+      {...pool, createdAt: undefined, updatedAt: undefined, id: undefined, ownerId: undefined},
     )
 
     const documentBatch = {

--- a/schema.json
+++ b/schema.json
@@ -67,14 +67,32 @@
         "description": "The index of the utxo"
       }
     },
-    "required": [
-      "txHash",
-      "vout",
-      "$createdAt",
-      "$updatedAt"
-    ],
-    "indices":  [
-      {"properties":  ["poolId"]}
+    "required": ["txHash", "vout", "$createdAt", "$updatedAt"],
+    "indices": [{ "name": "poolIdIndex", "properties": [{"poolId": "asc"}] }],
+    "additionalProperties": false
+  },
+  "message": {
+    "type": "object",
+    "properties": {
+      "channel": {
+        "position": 0,
+        "type": "string",
+        "description": "Channel ID: 'global' or poolId",
+        "maxLength": 63
+      },
+      "text": {
+        "position": 1,
+        "type": "string",
+        "description": "Chat message text",
+        "maxLength": 1000
+      }
+    },
+    "required": ["channel", "text", "$createdAt", "$updatedAt"],
+    "indices": [
+      {
+        "name": "message_channel_createdAt",
+        "properties": [{ "channel": "asc" }, { "$createdAt": "asc" }]
+      }
     ],
     "additionalProperties": false
   }

--- a/schema.json
+++ b/schema.json
@@ -121,5 +121,76 @@
       }
     ],
     "additionalProperties": false
+  },
+  "action_proposal": {
+    "type": "object",
+    "properties": {
+      "poolId": {
+        "position": 0,
+        "type": "string",
+        "description": "Base58-encoded Pool ID",
+        "maxLength": 63
+      },
+      "transactionHex": {
+        "position": 1,
+        "type": "string",
+        "description": "Unsigned multisig transaction in hex"
+      },
+      "description": {
+        "position": 2,
+        "type": "string",
+        "maxLength": 1000,
+        "description": "Human-readable explanation of the proposal"
+      }
+    },
+    "required": [
+      "poolId",
+      "transactionHex",
+      "description",
+      "$createdAt",
+      "$updatedAt"
+    ],
+    "indices": [
+      {
+        "name": "idx_actionProposal_pool",
+        "properties": [
+          { "poolId": "asc" }
+        ]
+      }
+    ],
+    "additionalProperties": false
+  },
+
+  "action_proposal_signature": {
+    "type": "object",
+    "properties": {
+      "proposalId": {
+        "position": 0,
+        "type": "string",
+        "description": "Base58-encoded ID of the action_proposal document",
+        "maxLength": 63
+      },
+      "signature": {
+        "position": 1,
+        "type": "string",
+        "maxLength": 2048,
+        "description": "Member's signature over the proposal transaction"
+      }
+    },
+    "required": [
+      "proposalId",
+      "signature",
+      "$createdAt",
+      "$updatedAt"
+    ],
+    "indices": [
+      {
+        "name": "idx_signature_proposal",
+        "properties": [
+          { "proposalId": "asc" }
+        ]
+      }
+    ],
+    "additionalProperties": false
   }
 }


### PR DESCRIPTION
### Description

This PR implements support for **action proposals** and their **signatures**. Users can now propose multisig transactions for a pool, list and fetch those proposals, and collect individual member signatures. The new features include:

* Data contract updates for `action_proposal` and `action_proposal_signature` schemas
* Domain models, repositories, actions, and CLI commands for both proposals and signatures
* A streamlined workflow: only the pool owner can create proposals, everyone can view them, and signatures are scoped to a specific proposal

---

### Changes

#### Data Contract

* **`action_proposal`**

  * Stores `poolId` as a string
  * Indexed on `poolId`
  
* **`action_proposal_signature`**

  * Removed `poolId` field
  * Now only `proposalId` and `signature`, indexed on `proposalId`

#### Models

* Added **`ActionProposal`** and **`ActionProposalSignature`** classes in `models/`
* Extended **`Pool`** model with optional `ownerId` for ownership checks

#### Repositories

* **`ActionProposalRepository`**

  * `getById(proposalId)`
  * `getByPoolId(poolId)`
  * `create({ poolId, transactionHex, description })`
* **`ActionProposalSignatureRepository`**

  * `getByProposalId(proposalId)`
  * `getById(signatureId)`
  * `create({ proposalId, signature })`

#### Actions

* **Proposals**

  * `getActionProposalByIdAction`
  * `getActionProposalByPoolIdAction`
  * `createActionProposalAction`
    – Enforces owner-only creation, public listing
* **Signatures**

  * `getActionProposalSignatureByProposalIdAction`
  * `getActionProposalSignatureByIdAction`
  * `createActionProposalSignatureAction`
    – Fetches/creates signatures after validating proposal existence

#### CLI Commands

* **Proposal** group

  * `proposal get <proposalId>`
  * `proposal list <poolId>`
  * `proposal create <poolId> <txHex> <description>`
* **Signature** group

  * `signature list <proposalId>`
  * `signature get <signatureId>`
  * `signature create <proposalId> <signature>`

#### Error Handling

* New custom errors for clarity:

  * `ActionProposalNotFoundError`
  * `ActionProposalSignatureNotFoundError`
  * `OnlyPoolOwnerError`

---

### Testing

#### Unit & Integration

* Verified **only pool owner** can run `proposal create`
* Confirmed `proposal list` & `proposal get` work for any user
* Ensured `signature list` & `signature get` return correct data after proposals exist
* Validated `signature create` stores ownership metadata and rejects non-existent proposals

#### Schema Validation

* Deployed updated data contract to Dash Platform; indexes created without JSON schema errors

#### CLI

* Manual end-to-end tests of all new commands:

  * Creating proposals
  * Fetching proposals
  * Signing proposals
  * Viewing signatures
* Edge-case checks: invalid IDs, missing proposals, unauthorized creation attempts
